### PR TITLE
Localize title of RFID box

### DIFF
--- a/src/components/blocks/configuration/Rfid.svelte
+++ b/src/components/blocks/configuration/Rfid.svelte
@@ -123,7 +123,7 @@
 	
 </style>
 {#if mounted}
-<Box title="RFID" icon="bx:rfid" back={true}>
+<Box title={$_("config.titles.rfid")} icon="bx:rfid" back={true}>
 
 	<div class="pb-1 is-flex is-align-items-center is-justify-content-center">
 		<Borders classes={$config_store.rfid_enabled?"has-background-primary-light":"has-background-light"}>


### PR DESCRIPTION
The RFID box title wasn't localized, so you'd see the localized title in the list of settings, but when you clicked through the box title would swap to unlocalized "RFID".