### PR TITLE
Change to official OCA-OCPP logo

### DIFF
--- a/src/components/blocks/configuration/Ocpp.svelte
+++ b/src/components/blocks/configuration/Ocpp.svelte
@@ -71,7 +71,7 @@
 </style>
 
 {#if mounted}
-<Box title={$_("config.titles.ocpp")} icon="custom:arduinoocpp" has_help={true} back={true}>
+<Box title={$_("config.titles.ocpp")} icon="custom:ocpp" has_help={true} back={true}>
 	<div slot="help">
 		<OcppHelp />
 	</div>

--- a/src/lib/icons/icons.js
+++ b/src/lib/icons/icons.js
@@ -106,10 +106,10 @@
 		width: 24,
 		height: 24,
 	});
-	addIcon('custom:arduinoocpp', {
-		body: '<path fill="currentColor" d="M 272 95 L 272 129 Q 272 144 287 144 L 289 144 Q 304 144 319 147 Q 384 160 384 241 Q 384 256 384 271 Q 384 352 319 365 Q 304 368 289 368 L 287 368 Q 272 368 272 383 L 272 417 Q 272 432 287 432 L 321 432 Q 336 432 350 428 Q 448 400 448 271 Q 448 256 448 241 Q 448 112 350 84 Q 336 80 321 80 L 287 80 Q 272 80 272 95 Z"/><ellipse fill="currentColor" cx="291" cy="256" rx="50" ry="57"/><path fill="currentColor" d="M 63 432 L 97 432 Q 112 432 117 418 L 235 94 Q 240 80 225 80 L 191 80 Q 176 80 171 94 L 53 418 Q 48 432 63 432 Z"/>',
-		width: 512,
-		height: 512,
+	addIcon('custom:ocpp', {
+		body: '<path fill="currentColor" d="M 15 7 C 10 7 0 9 0 20 C 0 29 7 41 24 41 C 34 41 48 37 48 27 C 48 17 29 7 15 7 Z M 16 11 C 16 11 13 13 13 21 C 13 32 19 37 19 37 C 19 37 5 34 5 20 C 5 19 5 11 16 11 Z"/><path fill="currentColor" d="M 15 16 L 15 20 L 4 20 L 4 16 Z M 15 25 L 15 29 L 4 29 L 4 25 Z"/>',
+		width: 48,
+		height: 48,
 	});
 	addIcon('ic:outline-save-alt', {
 		body: '<path fill="currentColor" d="M19 12v7H5v-7H3v7c0 1.1.9 2 2 2h14c1.1 0 2-.9 2-2v-7h-2zm-6 .67l2.59-2.58L17 11.5l-5 5l-5-5l1.41-1.41L11 12.67V3h2v9.67z"/>',

--- a/src/routes/Configuration.svelte
+++ b/src/routes/Configuration.svelte
@@ -21,7 +21,7 @@
 				<ConfigMenuButton url="/configuration/shaper" icon="fa6-solid:building-shield" name={$_("config.titles.shaper")} />
 				<ConfigMenuButton url="/configuration/selfproduction" icon="fa6-solid:solar-panel" name={$_("config.titles.selfprod")} height="1.3em" />
 				<ConfigMenuButton url="/configuration/vehicle" icon="bi:ev-front" name={$_("config.titles.vehicle")} />
-				<ConfigMenuButton url="/configuration/ocpp" icon="custom:arduinoocpp" name={$_("config.titles.ocpp")} />
+				<ConfigMenuButton url="/configuration/ocpp" icon="custom:ocpp" name={$_("config.titles.ocpp")} />
 				<ConfigMenuButton url="/configuration/emoncms" icon="fa6-solid:chart-bar" name={$_("config.titles.emon")} />
 				<ConfigMenuButton url="/configuration/ohmconnect" icon="mdi:energy-circle" name={$_("config.titles.ohm")} />
 				<ConfigMenuButton url="/configuration/dev" icon="mdi:console" name={$_("config.titles.dev")} />


### PR DESCRIPTION
Not super important, but since I will continue the OCPP library under a different name, the logo in the OpenEVSE GUI is becoming outdated. I suggest to change it to the official OCPP logo by the OCA. The result looks like this:

![image](https://github.com/OpenEVSE/openevse-gui-v2/assets/63792403/54256119-e5fd-48b2-8667-69b9005ea7f8)

I tried to make it look like this:

![image](https://github.com/OpenEVSE/openevse-gui-v2/assets/63792403/12bdf80f-322f-4124-a689-6964f2cf0d28)

If someone finds the official .svg, please do not hesitate to replace this.