### PR TITLE
feat(scheduler): add Eco timer state

### DIFF
--- a/src/components/blocks/Status.svelte
+++ b/src/components/blocks/Status.svelte
@@ -187,17 +187,17 @@
 					state={$claims_target_store.properties?.state} />
 
 				{:else if $uistates_store.stateclaimfrom == "timer"}
-				<TaskDisplay 
+				<TaskDisplay
 					mode={$_("clients.timer")}
-					msg={$plan_store.current_event?.state=="active"?$_("status-task-timer-activated"):$_("status-task-timer-disabled")} 
-					state={$plan_store.current_event?.state} 
+					msg={$plan_store.current_event?.state=="active"?$_("status-task-timer-activated"):$plan_store.current_event?.state=="eco"?$_("status-task-timer-eco"):$_("status-task-timer-disabled")}
+					state={$plan_store.current_event?.state}
 					time={$plan_store.current_event?.time} />
 
 					{#if $plan_store.current_event?.state != $plan_store.next_event?.state}
-					<TaskDisplay 
-						mode="timer" 
-						msg={$plan_store.next_event.state=="active"?$_("status-task-timer-activate"):$_("status-task-timer-disable")} 
-						state={$plan_store.next_event?.state} 
+					<TaskDisplay
+						mode="timer"
+						msg={$plan_store.next_event.state=="active"?$_("status-task-timer-activate"):$plan_store.next_event.state=="eco"?$_("status-task-timer-eco-at"):$_("status-task-timer-disable")}
+						state={$plan_store.next_event?.state}
 						time={$plan_store.next_event?.time} />
 					{/if}
 				{/if}

--- a/src/components/blocks/scheduler/TimerModal.svelte
+++ b/src/components/blocks/scheduler/TimerModal.svelte
@@ -209,16 +209,18 @@
 					<div class="has-text-dark has-text-centered has-text-weight-semibold">{$_("scheduler-state")}</div>
 					
 						{#if timer == null}
-						<div class="select {default_timer.state=="active"?"is-primary":"is-danger"}" >
+						<div class="select {default_timer.state=="active"?"is-primary":default_timer.state=="eco"?"is-warning":"is-danger"}" >
 							<select bind:this={select} bind:value={default_timer.state}>
 								<option value="active" selected>{$_("active")}</option>
+								<option value="eco">{$_("eco")}</option>
 								<option value="disabled">{$_("disabled")}</option>
 							</select>
 							</div>
 						{:else}
-						<div class="select {schedules[timer].state=="active"?"is-primary":"is-dark"}" >
+						<div class="select {schedules[timer].state=="active"?"is-primary":schedules[timer].state=="eco"?"is-warning":"is-dark"}" >
 							<select bind:value={schedules[timer].state}>
 								<option value="active">{$_("active")}</option>
+								<option value="eco">{$_("eco")}</option>
 								<option value="disabled">{$_("disabled")}</option>
 							</select>
 						</div>

--- a/src/components/ui/TimerTableRow.svelte
+++ b/src/components/ui/TimerTableRow.svelte
@@ -40,7 +40,7 @@
 <tr>
 	<!-- <th>{t_id}</th> -->
 	<th style="width:20%" class="is-size-7-mobile has-text-dark">{displayTime(t_time)}</th>
-	<th style="width:10%"><span class="tag {t_state === 'active'?'is-primary':'is-dark'} tags py-0 is-capitalized">{t_state == "active"?$_("active"):$_("disabled")}</span></th>
+	<th style="width:10%"><span class="tag {t_state === 'active'?'is-primary':t_state === 'eco'?'is-warning':'is-dark'} tags py-0 is-capitalized">{t_state == "active"?$_("active"):t_state == "eco"?$_("eco"):$_("disabled")}</span></th>
 	<th style="" class="is-size-4 m0 py-1">
 		<div class="is-flex is-justify-content-center">
 

--- a/src/lib/i18n/en.json
+++ b/src/lib/i18n/en.json
@@ -1,5 +1,6 @@
 {
     "active": "Active",
+    "eco": "Eco",
     "disabled": "Disabled",
     "disable": "Disable",
     "enabled": "Enabled",
@@ -89,8 +90,10 @@
     "status-task-rfidok-msg": "RFID badge ok, enabling charge",
     "status-task-timer-activated": "Activated since",
     "status-task-timer-disabled": "Disabled since",
+    "status-task-timer-eco": "Eco since",
     "status-task-timer-activate": "Activate at",
     "status-task-timer-disable": "Disable at",
+    "status-task-timer-eco-at": "Eco at",
     "status-divert-production": "Production",
     "status-divert-grid": "Grid +Import/-Export",
     "status-current-available": "Available Current",

--- a/src/lib/i18n/es.json
+++ b/src/lib/i18n/es.json
@@ -1,5 +1,6 @@
 {
 	"active": "Activo",
+	"eco": "Eco",
 	"disabled": "Desactivado",
 	"disable": "Desactivar",
 	"enabled": "Activado",
@@ -89,8 +90,10 @@
 	"status-task-rfidok-msg": "Tarjeta RFID correcta, habilitada carga",
 	"status-task-timer-activated": "Activada desde",
 	"status-task-timer-disabled": "Desactivada desde",
+	"status-task-timer-eco": "Eco desde",
 	"status-task-timer-activate": "Activar en",
 	"status-task-timer-disable": "Desactivar en",
+	"status-task-timer-eco-at": "Eco en",
 	"status-divert-production": "Producción",
 	"status-divert-grid": "Grid +Importar/-Exportar",
 	"status-current-available": "Corriente disponible",

--- a/src/lib/i18n/fr.json
+++ b/src/lib/i18n/fr.json
@@ -1,5 +1,6 @@
 {
     "active": "Activé",
+    "eco": "Eco",
     "disabled": "Désactivé",
     "disable": "Désactiver",
     "enabled": "Activé",
@@ -89,8 +90,10 @@
     "status-task-rfidok-msg": "Badge RFID ok, activation en cours",
     "status-task-timer-activated": "Activé depuis",
     "status-task-timer-disabled": "Désactivé depuis",
+    "status-task-timer-eco": "Eco depuis",
     "status-task-timer-activate": "Activé à",
     "status-task-timer-disable": "Désactivé à",
+    "status-task-timer-eco-at": "Eco à",
     "status-divert-production": "Production",
     "status-divert-grid": "Réseau +Import/-Export",
     "status-current-available": "Courant disponible",

--- a/src/lib/i18n/hu.json
+++ b/src/lib/i18n/hu.json
@@ -1,5 +1,6 @@
 {
 	"active": "Aktív",
+	"eco": "Eco",
 	"disabled": "Letiltva",
 	"disable": "Letiltás",
 	"enabled": "Engedélyezve",
@@ -89,8 +90,10 @@
 	"status-task-rfidok-msg": "RFID jelvény rendben, töltés engedélyezése",
 	"status-task-timer-activated": "Aktiválva",
 	"status-task-timer-disabled": "Letiltva",
+	"status-task-timer-eco": "Eco óta",
 	"status-task-timer-activate": "Aktiválás",
 	"status-task-timer-disable": "Letiltás",
+	"status-task-timer-eco-at": "Eco időpont",
 	"status-divert-production": "Termelés",
 	"status-divert-grid": "Hálózat +Import / -Export",
 	"status-current-available": "Elérhető Áram",

--- a/src/lib/stores/schedule.js
+++ b/src/lib/stores/schedule.js
@@ -11,6 +11,7 @@ function createScheduleStore() {
                 for ( let t = 0; t < res.length ; t++) {
                     res[t].time = res[t].time.slice(0,5) // remove useless seconds
                 }
+                res.sort((a, b) => a.time.localeCompare(b.time))
                 P.update(() => res)
                 return true
             }


### PR DESCRIPTION
I run timers on my charger but want some windows to charge from solar surplus instead of pulling a fixed current. The scheduler only offered Active and Disabled, so this adds an Eco state.

## Changes
- Eco option in the timer state dropdown, styled yellow in the timer modal and the schedule table rows to set it apart from active (green) and disabled (red).
- Eco-specific status messages on the dashboard ("Eco since" / "Eco at").
- The schedule list is sorted by time.
- en/es/fr/hu strings for the new option and messages.

## Companion changes
This matches the same Eco state in the nightshift UI and pairs with a firmware scheduler change (`EvseState::Eco` switching to `DivertMode::Eco`) in `openevse_esp32_firmware`. The UI sends state `"eco"` over the existing schedule API.
